### PR TITLE
Add usos provider and integrate it with courses and test endpoints

### DIFF
--- a/Backend/docker/setup/db_files/00_init_structure.sql
+++ b/Backend/docker/setup/db_files/00_init_structure.sql
@@ -27,15 +27,16 @@ CREATE TABLE IF NOT EXISTS "system"."course"
     "name"        varchar NOT NULL,
     "usos_id"   varchar NOT NULL,
     "course_type"  varchar(1) NOT NULL,
-    UNIQUE(usos_id, course_type)
+    UNIQUE(usos_id, course_type, teacher_id)
 );
 
 CREATE TABLE  IF NOT EXISTS  "system"."teacher"
 (
     "id"          uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     "name"        varchar NOT NULL,
-    "second_name" varchar,
-    "surname"     varchar NOT NULL
+    "second_name" varchar NOT NULL,
+    "surname"     varchar NOT NULL,
+    UNIQUE (name, second_name, surname)
 );
 
 CREATE TABLE IF NOT EXISTS "system"."question"

--- a/Backend/docker/setup/db_files/01_add_mocks.sql
+++ b/Backend/docker/setup/db_files/01_add_mocks.sql
@@ -1,5 +1,5 @@
 insert into system.teacher (id, name, second_name, surname) VALUES
-('eb247366-dee4-40dc-8610-122e937d3a21', 'Tomasz', null, 'Kapłon'),
+('eb247366-dee4-40dc-8610-122e937d3a21', 'Tomasz', '', 'Kapłon'),
 ('9b0942c5-1305-4be1-88e3-1b116958a8f7', 'Paweł', 'Krzysztof', 'Głuchowski');
 
 insert into system.course(id, teacher_id, name, usos_id, course_type) VALUES

--- a/Backend/src/dal/course.go
+++ b/Backend/src/dal/course.go
@@ -28,6 +28,17 @@ func GetCourseFromDB(id uuid.UUID) (*model.Course, error) {
 	return &course, nil
 }
 
+func GetCourseByUniqueKey(usosId string, teacherId uuid.UUID, courseType string) (*model.Course, error) {
+	var course model.Course
+	result := DB.
+		Where("usos_id = ? AND teacher_id = ? AND course_type = ?", usosId, teacherId, courseType).
+		First(&course)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &course, nil
+}
+
 func UpdateCourseInDB(newCourse *model.Course) error {
 	var course model.Course
 	result := DB.First(&course, newCourse.Id)

--- a/Backend/src/dal/teacher.go
+++ b/Backend/src/dal/teacher.go
@@ -19,6 +19,17 @@ func GetTeachersFromDB() ([]model.Teacher, error) {
 	return teachers, nil
 }
 
+func GetTeacherByUniqueKey(firstName string, lastName string, secondName string) (*model.Teacher, error) {
+	var teacher model.Teacher
+	result := DB.
+		Where("name = ? AND surname = ? AND second_name = ?", firstName, lastName, secondName).
+		First(&teacher)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &teacher, nil
+}
+
 //make teacher optional
 
 func GetTeacherFromDB(id uuid.UUID) (*model.Teacher, error) {

--- a/Backend/src/dal/test.go
+++ b/Backend/src/dal/test.go
@@ -21,6 +21,18 @@ func GetTestsFromDB() ([]model.Test, error) {
 	return tests, nil
 }
 
+func GetTestsById(courseIds []uuid.UUID) ([]model.Test, error) {
+	var tests []model.Test
+	result := DB.Preload("Course").
+		Preload("Course.Teacher").
+		Where("course_id IN ?", courseIds).
+		Find(&tests)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return tests, nil
+}
+
 func GetTestFromDB(id uuid.UUID) (*model.Test, error) {
 	var test model.Test
 	result := DB.Preload("Course").

--- a/Backend/src/main/docs/docs.go
+++ b/Backend/src/main/docs/docs.go
@@ -1058,6 +1058,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/test/active": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all user active tests",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Get active tests",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/src_model_dto.ListTest"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/src_model_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/test/{id}": {
             "get": {
                 "security": [
@@ -1353,6 +1387,9 @@ const docTemplate = `{
         "src_model_dto.FullCourse": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "courseType": {
                     "type": "string"
                 },

--- a/Backend/src/main/docs/swagger.json
+++ b/Backend/src/main/docs/swagger.json
@@ -1050,6 +1050,40 @@
                 }
             }
         },
+        "/api/v1/test/active": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all user active tests",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "test"
+                ],
+                "summary": "Get active tests",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/src_model_dto.ListTest"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/src_model_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/test/{id}": {
             "get": {
                 "security": [
@@ -1345,6 +1379,9 @@
         "src_model_dto.FullCourse": {
             "type": "object",
             "properties": {
+                "active": {
+                    "type": "boolean"
+                },
                 "courseType": {
                     "type": "string"
                 },

--- a/Backend/src/main/docs/swagger.yaml
+++ b/Backend/src/main/docs/swagger.yaml
@@ -92,6 +92,8 @@ definitions:
     type: object
   src_model_dto.FullCourse:
     properties:
+      active:
+        type: boolean
       courseType:
         type: string
       id:
@@ -980,6 +982,27 @@ paths:
       security:
       - BearerAuth: []
       summary: Update test
+      tags:
+      - test
+  /api/v1/test/active:
+    get:
+      description: Get all user active tests
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/src_model_dto.ListTest'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/src_model_dto.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get active tests
       tags:
       - test
 securityDefinitions:

--- a/Backend/src/model/dto/course.go
+++ b/Backend/src/model/dto/course.go
@@ -11,14 +11,16 @@ type FullCourse struct {
 	Teacher    model.Teacher `json:"teacher"`
 	UsosId     string        `json:"usosId"`
 	CourseType string        `json:"courseType"`
+	Active     bool          `json:"active"`
 }
 
-func ToFullCourse(course model.Course) FullCourse {
+func ToFullCourse(course model.Course, active bool) FullCourse {
 	return FullCourse{
 		Id:         course.Id,
 		Name:       course.Name,
 		Teacher:    *course.Teacher,
 		UsosId:     course.UsosId,
 		CourseType: course.CourseType,
+		Active:     active,
 	}
 }

--- a/Backend/src/services/auth.go
+++ b/Backend/src/services/auth.go
@@ -43,6 +43,7 @@ func RequireAuth(c *gin.Context) {
 		}
 		// Attach the request
 		c.Set("user", sub)
+		c.Set("token", "Bearer "+tokenString)
 		c.Next()
 	} else {
 		c.AbortWithStatus(http.StatusUnauthorized)

--- a/Backend/src/services/course.go
+++ b/Backend/src/services/course.go
@@ -61,9 +61,11 @@ func GetCoursesHandle(ctx *gin.Context) {
 		ctx.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
+	activeCourses, _ := GetActiveUserCourses(ctx)
 	output := make([]dto.FullCourse, 0, len(courses))
 	for _, course := range courses {
-		output = append(output, dto.ToFullCourse(course))
+		_, active := activeCourses[course.Id]
+		output = append(output, dto.ToFullCourse(course, active))
 	}
 	ctx.JSON(200, output)
 }
@@ -89,7 +91,9 @@ func GetCourseHandle(ctx *gin.Context) {
 		ctx.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	ctx.JSON(200, dto.ToFullCourse(*course))
+	activeCourses, _ := GetActiveUserCourses(ctx)
+	_, active := activeCourses[course.Id]
+	ctx.JSON(200, dto.ToFullCourse(*course, active))
 }
 
 // UpdateCourse            godoc

--- a/Backend/src/services/test.go
+++ b/Backend/src/services/test.go
@@ -91,6 +91,30 @@ func GetTestsHandle(ctx *gin.Context) {
 	ctx.JSON(200, output)
 }
 
+// GetActiveTests            godoc
+// @Summary      Get active tests
+// @Description  Get all user active tests
+// @Tags         test
+// @Produce      json
+// @Success      200  {array}  dto.ListTest
+// @Failure     500  {object} dto.ErrorResponse
+// @Security     BearerAuth
+// @Router       /api/v1/test/active [get]
+func GetActiveTestsHandle(ctx *gin.Context) {
+	_, activeCourses := GetActiveUserCourses(ctx)
+	tests, err := dal.GetTestsById(activeCourses)
+	if err != nil {
+		ctx.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	//loop over tests and convert to listTest
+	output := make([]dto.ListTest, len(tests))
+	for i, test := range tests {
+		output[i] = dto.ToListTest(test)
+	}
+	ctx.JSON(200, output)
+}
+
 // GetTest            godoc
 // @Summary      Get test
 // @Description  Get test by id
@@ -192,4 +216,5 @@ func AddTestHandlers(router *gin.RouterGroup) {
 	subGroup.GET(":id", GetTestHandle)
 	subGroup.PUT(":id", UpdateTestHandle)
 	subGroup.DELETE(":id", DeleteTestHandle)
+	subGroup.GET("active", GetActiveTestsHandle)
 }

--- a/Backend/src/services/usos_provider.go
+++ b/Backend/src/services/usos_provider.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"io"
+	"net/http"
+	"os"
+	"src/dal"
+	"src/model"
+	"time"
+)
+
+type ServiceResponse struct {
+	ID        string    `json:"Id"`
+	Name      string    `json:"Name"`
+	StartDate time.Time `json:"StartDate"`
+	EndDate   time.Time `json:"EndDate"`
+	Courses   []struct {
+		ID      string `json:"Id"`
+		Name    string `json:"Name"`
+		UsosURL string `json:"UsosUrl"`
+		Groups  []struct {
+			ID       string `json:"Id"`
+			Type     string `json:"Type"`
+			Lecturer struct {
+				ID        string `json:"Id"`
+				FirstName string `json:"FirstName"`
+				LastName  string `json:"LastName"`
+			} `json:"Lecturer"`
+		} `json:"Groups"`
+	} `json:"Courses"`
+}
+
+type CacheEntry struct {
+	CoursesMap   map[uuid.UUID]bool
+	CoursesList  []uuid.UUID
+	ValidThrough time.Time
+}
+
+// cache active courses along with user id and validThrough date
+var coursesCache = make(map[string]CacheEntry)
+var cacheInitialized = false
+var cacheFile = "cache.json"
+
+func GetActiveUserCourses(ctx *gin.Context) (map[uuid.UUID]bool, []uuid.UUID) {
+	if !cacheInitialized {
+		loadCache()
+		cacheInitialized = true
+	}
+	user, exists := ctx.Get("user")
+	if !exists {
+		fmt.Println("User not found in context")
+		return nil, nil
+	}
+	entry, exists := coursesCache[user.(string)]
+	if exists && entry.ValidThrough.After(time.Now()) {
+		return entry.CoursesMap, entry.CoursesList
+	}
+
+	token, exists := ctx.Get("token")
+	if !exists {
+		fmt.Println("Token not found in context")
+		return nil, nil
+	}
+	usosService := os.Getenv("USER_COURSES_ENDPOINT")
+	if usosService == "" {
+		fmt.Println("USER_COURSES_ENDPOINT env var not set")
+		return nil, nil
+	}
+	response := fetchServiceData(token.(string), usosService)
+	if response == nil {
+		return nil, nil
+	}
+	return updateDbData(response, user.(string))
+}
+
+func fetchServiceData(token string, endpoint string) *ServiceResponse {
+	req, _ := http.NewRequest("GET", endpoint, nil)
+	req.Header.Add("Authorization", token)
+
+	// Send req using http Client
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println("Error while sending the request.\n[ERROR] -", err)
+		return nil
+	}
+
+	// Read the response body
+	body, _ := io.ReadAll(resp.Body)
+	err = resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		fmt.Println("Error while fetching data from service.\n[ERROR] -", err)
+		return nil
+	}
+	var result ServiceResponse
+	if err := json.Unmarshal(body, &result); err != nil { // Parse []byte to go struct pointer
+		fmt.Println("Can not unmarshal JSON")
+		return nil
+	}
+	return &result
+}
+
+func updateDbData(response *ServiceResponse, user string) (map[uuid.UUID]bool, []uuid.UUID) {
+	coursesMap := make(map[uuid.UUID]bool)
+	coursesList := make([]uuid.UUID, 0)
+	groupsNumber := 0
+	for _, course := range response.Courses {
+		courseName := course.Name
+		usosId := course.ID
+		for _, group := range course.Groups {
+			groupsNumber++
+			id := upsertTeacher(group.Lecturer.FirstName, group.Lecturer.LastName)
+			if id == nil {
+				continue
+			}
+			courseId := upsertCourse(courseName, usosId, group.Type, *id)
+			if courseId != nil {
+				coursesMap[*courseId] = true
+				coursesList = append(coursesList, *courseId)
+			}
+		}
+	}
+	if groupsNumber != len(coursesList) {
+		fmt.Println("Some courses were not added to the database")
+		return nil, nil
+	}
+	validThrough := response.EndDate
+	updateCache(user, validThrough, coursesMap, coursesList)
+	return coursesMap, coursesList
+}
+
+func upsertCourse(courseName string, usosId string, courseType string, teacherId uuid.UUID) *uuid.UUID {
+	id, _ := uuid.NewV4()
+	course := model.Course{
+		Id:         id,
+		Name:       courseName,
+		UsosId:     usosId,
+		CourseType: courseType,
+		TeacherId:  teacherId,
+	}
+	err := dal.AddCourseToDB(&course)
+	if err != nil {
+		course, _ := dal.GetCourseByUniqueKey(usosId, teacherId, courseType)
+		if course != nil {
+			return &course.Id
+		}
+		fmt.Println(fmt.Sprintf("Error while processing course: %s %s %s", courseName, usosId, courseType))
+		return nil
+	}
+	return &id
+}
+
+func upsertTeacher(firstName string, lastName string) *uuid.UUID {
+	id, _ := uuid.NewV4()
+	teacher := model.Teacher{
+		Id:         id,
+		Name:       firstName,
+		Surname:    lastName,
+		SecondName: "",
+	}
+	err := dal.AddTeacherToDB(&teacher)
+	if err != nil {
+		teacher, _ := dal.GetTeacherByUniqueKey(firstName, lastName, "")
+		if teacher != nil {
+			return &teacher.Id
+		}
+		fmt.Println(fmt.Sprintf("Error while processing teacher: %s %s", firstName, lastName))
+		return nil
+	}
+	return &id
+}
+
+func updateCache(userId string, validThrough time.Time, coursesMap map[uuid.UUID]bool, coursesList []uuid.UUID) {
+	coursesCache[userId] = CacheEntry{
+		CoursesMap:   coursesMap,
+		CoursesList:  coursesList,
+		ValidThrough: validThrough,
+	}
+
+	// Save cache to filesystem
+	cacheData, err := json.Marshal(coursesCache)
+	if err != nil {
+		fmt.Println("Error while marshalling cache data:", err)
+	}
+
+	err = os.WriteFile(cacheFile, cacheData, os.ModePerm)
+	if err != nil {
+		fmt.Println("Error while writing cache data to file:", err)
+	}
+}
+
+func loadCache() {
+	// Load cache from filesystem
+	cacheData, err := os.ReadFile(cacheFile)
+	if err != nil {
+		fmt.Println("Error while reading cache data from file:", err)
+		return
+	}
+	//bind cache data to cache map
+	err = json.Unmarshal(cacheData, &coursesCache)
+	if err != nil {
+		fmt.Println("Error while unmarshalling cache data:", err)
+	} else {
+		fmt.Println("Cache loaded successfully")
+	}
+}


### PR DESCRIPTION
# Major backend changes
-  implement UsosProvider which connects with UsosConnector module to retrieve user courses:
    -  perform update of courses and teachers based on user courses
    -  cache results till user's current semester end date
    -  load cache on startup and save in filesystem on update
-  integrate active courses data into system:
    -  courses get endpoints 
    -  [new] active tests endpoint